### PR TITLE
Add diagnostic mode and harden ads configuration

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,13 @@
+# Flutter embedding
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+
+# Google Mobile Ads SDK
+-keep class com.google.android.gms.ads.** { *; }
+-keep interface com.google.android.gms.ads.** { *; }
+-keepclassmembers class com.google.android.gms.ads.** { *; }
+
+# Google User Messaging Platform (UMP)
+-keep class com.google.android.ump.** { *; }
+-keep interface com.google.android.ump.** { *; }
+-keepclassmembers class com.google.android.ump.** { *; }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,34 @@
 // lib/main.dart
+import 'dart:async';
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
+import 'ui/diag_page.dart';
 import 'ui/home_page.dart';
+
+const bool kDiagMode = true;
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(const RaidCalcApp());
+
+  FlutterError.onError = (details) {
+    FlutterError.presentError(details);
+    _reportError(details.exception, details.stack ?? StackTrace.empty);
+  };
+
+  ui.PlatformDispatcher.instance.onError = (error, stack) {
+    _reportError(error, stack);
+    return true;
+  };
+
+  runZonedGuarded(
+    () => runApp(const RaidCalcApp()),
+    _reportError,
+  );
+}
+
+void _reportError(Object error, StackTrace stack) {
+  // ignore: avoid_print
+  print('UNCAUGHT ERROR: $error\n$stack');
 }
 
 class RaidCalcApp extends StatelessWidget {
@@ -23,7 +47,7 @@ class RaidCalcApp extends StatelessWidget {
           contentPadding: EdgeInsets.symmetric(vertical: 8),
         ),
       ),
-      home: const HomePage(),
+      home: kDiagMode ? const DiagPage() : const HomePage(),
       debugShowCheckedModeBanner: false,
     );
   }

--- a/lib/ui/diag_page.dart
+++ b/lib/ui/diag_page.dart
@@ -1,0 +1,76 @@
+// lib/ui/diag_page.dart
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import '../util/ad_helper.dart';
+import 'home_page.dart';
+
+class DiagPage extends StatefulWidget {
+  const DiagPage({super.key});
+  @override
+  State<DiagPage> createState() => _DiagPageState();
+}
+
+class _DiagPageState extends State<DiagPage> {
+  String status = 'Pronto';
+
+  Future<void> testAssets() async {
+    setState(() => status = 'Leggo assets/lang/it.json ...');
+    try {
+      final s = await rootBundle.loadString('assets/lang/it.json');
+      final map = json.decode(s) as Map<String, dynamic>;
+      setState(() => status = 'OK assets: ${map['app_title'] ?? 'app_title?'}');
+    } catch (e, st) {
+      setState(() => status = 'ERRORE assets: $e');
+      // ignore: avoid_print
+      print('ASSET ERROR: $e\n$st');
+    }
+  }
+
+  Future<void> testAdsInit() async {
+    setState(() => status = 'Init Ads (OFF in debug)...');
+    try {
+      await AdHelper.bootstrap(enableAds: false);
+      setState(() => status = 'OK init Ads (disabilitati)');
+    } catch (e, st) {
+      setState(() => status = 'ERRORE init Ads: $e');
+      // ignore: avoid_print
+      print('ADS INIT ERROR: $e\n$st');
+    }
+  }
+
+  void openHome() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const HomePage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text('Diag')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              Text(status),
+              const SizedBox(height: 12),
+              Row(children: [
+                ElevatedButton(
+                  onPressed: testAssets,
+                  child: const Text('Test assets'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: testAdsInit,
+                  child: const Text('Test ads init'),
+                ),
+              ]),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: openHome,
+                child: const Text('Apri HomePage'),
+              ),
+            ],
+          ),
+        ),
+      );

--- a/lib/util/ad_helper.dart
+++ b/lib/util/ad_helper.dart
@@ -29,7 +29,7 @@ class AdHelper {
 
   /// Chiamare una sola volta (es. in initState di HomePage).
   static Future<void> bootstrap({bool enableAds = true}) async {
-    enabled = enableAds && Platform.isAndroid;
+    enabled = enableAds && kReleaseMode && Platform.isAndroid;
     if (!_bootstrapped && enabled) {
       await MobileAds.instance.initialize();
       _bootstrapped = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,10 +14,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/raidComplete_data.json
-    - assets/lang/it.json
-    - assets/lang/en.json
-    - assets/lang/de.json
-    - assets/lang/fr.json
-    - assets/lang/es.json
-    - assets/lang/ru.json
-    - assets/lang/nl.json
+    - assets/lang/


### PR DESCRIPTION
## Summary
- add a diagnostic page and wire it as the temporary home with global error reporting hooks
- ensure ads are disabled outside release builds and keep the language assets directory exposed
- harden Android Proguard configuration for Google Mobile Ads and the UMP SDK

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceb93015c0832c86ee6b481214ed30