### PR TITLE
feat(ads): interstitial deterministic on Simula + fix API v5.x + proguard

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,12 @@
+# Flutter embedding
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+
+# Google Mobile Ads SDK
+-keep class com.google.android.gms.ads.** { *; }
+-keep interface com.google.android.gms.ads.** { *; }
+-keepclassmembers class com.google.android.gms.ads.** { *; }
+
+# UMP SDK (consent)
+-keep class com.google.android.ump.** { *; }
+-keepclassmembers class com.google.android.ump.** { *; }

--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -63,8 +63,7 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     _loadLang('it');
 
-    // Ads (safe): se fallisce, le ads si spengono e si va avanti
-    AdHelper.bootstrap(enableAds: false);
+    AdHelper.I.bootstrap();
   }
 
   @override
@@ -73,7 +72,7 @@ class _HomePageState extends State<HomePage> {
     for (final c in [..._kAtk, ..._kDef, ..._kHp, ..._kStun]) {
       c.dispose();
     }
-    AdHelper.dispose();
+    unawaited(AdHelper.I.dispose());
     super.dispose();
   }
 
@@ -138,10 +137,10 @@ class _HomePageState extends State<HomePage> {
     ));
   }
 
-  void _onSimulatePressed() {
+  void _onSimulatePressed() async {
     if (_running) return;
-    AdHelper.tryShow(); // non blocca
-    _runSimulation();
+    await AdHelper.I.show(context: context);
+    await _runSimulation();
   }
 
   @override


### PR DESCRIPTION
## Summary
- replace the AdHelper implementation to support Google Mobile Ads 5.x, test/production IDs, and richer logging
- bootstrap the ad helper from HomePage and await an interstitial before launching the simulation
- add the required ProGuard configuration for Google Mobile Ads and Flutter

## Testing
- unable to run `flutter pub get` (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d029bad638832cbe95339c553cbe1c