### PR TITLE
fix(ad_helper): build errors with google_mobile_ads 5.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ ios/Runner/GoogleService-Info.plist
 *.log
 *.orig
 *.rej
+*.bak
 
 # --- macOS/Windows/Linux ephemeral (se presenti) ---
 macos/Flutter/ephemeral/

--- a/lib/util/ad_helper.dart
+++ b/lib/util/ad_helper.dart
@@ -46,11 +46,11 @@ class AdHelper {
       final status = await MobileAds.instance.initialize();
       // stampa stato adapter (utile per emulatori senza Play Services)
       status.adapterStatuses.forEach((n, s) {
-        debugPrint('I/flutter [Ads] adapter[$n]=${s.description}, init=${s.initializationState}');
+        debugPrint('I/flutter [Ads] adapter[$n]=${s.description}, init=${s.state}');
       });
 
       await MobileAds.instance.updateRequestConfiguration(
-        const RequestConfiguration(testDeviceIds: <String>[]),
+        RequestConfiguration(testDeviceIds: <String>[]),
       );
 
       _bootstrapped = true;
@@ -135,7 +135,13 @@ class AdHelper {
 
     if (_ad == null) {
       unawaited(_load());
-      try { await (_loading?.future).timeout(const Duration(seconds: 2)); } catch (_) {}
+      if (_loading != null) {
+        try {
+          await _loading!.future.timeout(const Duration(seconds: 2));
+        } catch (_) {
+          // timeout o load fallito: va bene, proseguirà con i controlli successivi
+        }
+      }
     }
 
     final ad = _ad;


### PR DESCRIPTION
## Summary
- update the adapter status logging to use AdapterStatus.state expected by google_mobile_ads 5.x
- remove the const RequestConfiguration constructor so MobileAds.updateRequestConfiguration compiles again
- guard the interstitial loading completer before awaiting with timeout to avoid calling timeout on a nullable future
- ensure stray pubspec.yaml.bak is cleaned up and future *.bak files are ignored; AdMob unit ids remain unchanged

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d06c7ff4fc832c9e46db2e37270ab8